### PR TITLE
Fix emotion scoring and update GPT model

### DIFF
--- a/screens/EmotionAnalysisScreen.js
+++ b/screens/EmotionAnalysisScreen.js
@@ -30,8 +30,14 @@ const EmotionAnalysisScreen = ({ navigation }) => {
 
     setLoading(true);
 
-    setTimeout(() => {
-      const emotions = emotionAnalyzer.analyzeText(inputText);
+    setTimeout(async () => {
+      const emotions = await emotionAnalyzer.analyzeText(inputText);
+      if (!emotions) {
+        setLoading(false);
+        Alert.alert('오류', '감정 분석에 실패했습니다. 다시 시도해주세요.');
+        return;
+      }
+
       emotionAnalyzer.saveEmotionData(emotions, inputText);
 
       const dominantEmotion = Object.keys(emotions).reduce((a, b) =>

--- a/services/openai.js
+++ b/services/openai.js
@@ -30,7 +30,7 @@ export const getEmotionSummary = async (text) => {
         'Authorization': `Bearer ${OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: `다음 문장을 분석해주세요:
@@ -78,7 +78,7 @@ export const innerTalk = async (messages = []) => {
         'Authorization': `Bearer ${OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4',
         messages: [
           { role: 'system', content: systemPrompt },
           ...messages,
@@ -112,7 +112,7 @@ export const generateCBTInsights = async (sessionData) => {
         'Authorization': `Bearer ${OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: JSON.stringify(sessionData) },


### PR DESCRIPTION
## Summary
- handle async emotion analyzer result properly
- switch OpenAI model usage to `gpt-4`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_683f66d18710832f8fe8ecec10982620