### PR TITLE
Fix chat input blocked by keyboard

### DIFF
--- a/screens/InnerTalkScreen.js
+++ b/screens/InnerTalkScreen.js
@@ -7,7 +7,9 @@ import {
   TouchableOpacity,
   ScrollView,
   SafeAreaView,
-  ActivityIndicator
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { database } from '../lib/supabase';
@@ -71,7 +73,12 @@ const InnerTalkScreen = ({ route }) => {
   );
 
   return (
-    <SafeAreaView style={styles.container}>
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? 20 : 0}
+    >
+      <SafeAreaView style={styles.container}>
       <Text style={styles.title}>내면 대화</Text>
       <ScrollView
         style={styles.scrollView}
@@ -104,6 +111,7 @@ const InnerTalkScreen = ({ route }) => {
         </TouchableOpacity>
       </View>
     </SafeAreaView>
+    </KeyboardAvoidingView>
   );
 };
 


### PR DESCRIPTION
## Summary
- adjust InnerTalk screen so chat box shifts up when keyboard appears

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_683f686cafa4832fb408d0ea8ea4e5e6