### PR TITLE
Integrate emotion chart visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ const recommendations = emotionAnalyzer.generateRecommendations(emotions);
 ## 🔮 향후 계획
 
 ### 단기 목표 (1-2개월)
-- [ ] 감정 히스토리 차트 추가
+- [x] 감정 히스토리 차트 추가
 - [ ] 다국어 지원 (영어)
 - [ ] 오프라인 저장 기능
 - [ ] 알림 및 리마인더

--- a/screens/EmotionAnalysisScreen.js
+++ b/screens/EmotionAnalysisScreen.js
@@ -193,6 +193,18 @@ const EmotionAnalysisScreen = ({ navigation }) => {
                   </View>
                 ))}
             </View>
+
+            <TouchableOpacity
+              style={styles.viewResultButton}
+              onPress={() => navigation.navigate('EmotionResultScreen', { result: analysisResult })}
+            >
+              <LinearGradient
+                colors={['#7C3AED', '#A855F7']}
+                style={styles.buttonGradient}
+              >
+                <Text style={styles.viewResultText}>📈 시각화 보기</Text>
+              </LinearGradient>
+            </TouchableOpacity>
           </Animated.View>
         )}
       </View>
@@ -249,7 +261,9 @@ const styles = StyleSheet.create({
     textAlign: 'center', borderRadius: 10, fontSize: 12, fontWeight: '600',
     marginRight: 12, lineHeight: 20
   },
-  recommendationText: { flex: 1, fontSize: 14, color: '#374151', lineHeight: 20 }
+  recommendationText: { flex: 1, fontSize: 14, color: '#374151', lineHeight: 20 },
+  viewResultButton: { marginTop: 16, borderRadius: 12, overflow: 'hidden' },
+  viewResultText: { fontSize: 16, fontWeight: '600', color: 'white' }
 });
 
 export default EmotionAnalysisScreen;

--- a/screens/EmotionResultScreen.js
+++ b/screens/EmotionResultScreen.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, Dimensions } from 'react-native';
-import { PieChart } from 'react-native-chart-kit';
+import { PieChart, LineChart } from 'react-native-chart-kit';
+import { emotionAnalyzer } from '../utils/emotionAnalyzer';
 
 const EmotionResultScreen = ({ route }) => {
   const { emotions, dominantEmotion, recommendations, emotionScore } = route.params.result;
@@ -12,6 +13,20 @@ const EmotionResultScreen = ({ route }) => {
     legendFontColor: '#333',
     legendFontSize: 14,
   }));
+
+  const history = emotionAnalyzer.emotionHistory.slice(-7);
+  const lineData = {
+    labels: history.map(item => item.date.slice(5)),
+    datasets: [
+      {
+        data: history.map(item =>
+          emotionAnalyzer.calculateEmotionScore(item.emotions)
+        ),
+        color: () => '#7C3AED',
+        strokeWidth: 2,
+      },
+    ],
+  };
 
   return (
     <View style={styles.container}>
@@ -28,6 +43,20 @@ const EmotionResultScreen = ({ route }) => {
         center={[10, 10]}
         absolute
       />
+
+      {history.length > 1 && (
+        <>
+          <Text style={styles.historyTitle}>최근 감정 점수 추이</Text>
+          <LineChart
+            data={lineData}
+            width={Dimensions.get('window').width - 40}
+            height={220}
+            chartConfig={chartConfig}
+            bezier
+            style={{ marginVertical: 8 }}
+          />
+        </>
+      )}
 
       <Text style={styles.dominantText}>주된 감정: {dominantEmotion}</Text>
       <Text style={styles.scoreText}>감정 점수: {emotionScore.toFixed(2)}점</Text>
@@ -68,6 +97,13 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginTop: 16,
     color: '#7C3AED',
+  },
+  historyTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 24,
+    marginBottom: 8,
+    color: '#374151',
   },
   scoreText: {
     fontSize: 16,


### PR DESCRIPTION
## Summary
- connect `EmotionResultScreen` from analysis screen
- show pie chart and new line chart using saved emotion history
- mark history chart goal as done in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f68e53a6c832fa2854306155fa0c6