### PR TITLE
Fix emotion key mapping

### DIFF
--- a/services/openai.js
+++ b/services/openai.js
@@ -1,3 +1,5 @@
+import { EMOTION_CONFIG } from '../utils/emotionConstants';
+
 const OPENAI_API_KEY = process.env.EXPO_PUBLIC_OPENAI_API_KEY;
 const OPENAI_API_URL = 'https://api.openai.com/v1/chat/completions';
 
@@ -50,7 +52,19 @@ export const getEmotionSummary = async (text) => {
 
     try {
       const emotionResult = JSON.parse(jsonText);
-      return emotionResult;
+
+      const KOR_TO_ENG = Object.fromEntries(
+        Object.entries(EMOTION_CONFIG.NAMES).map(([en, ko]) => [ko, en])
+      );
+      const normalized = {};
+
+      Object.keys(emotionResult).forEach(key => {
+        const num = parseFloat(emotionResult[key]);
+        const engKey = KOR_TO_ENG[key] || key;
+        normalized[engKey] = Number.isNaN(num) ? 0 : num;
+      });
+
+      return normalized;
     } catch (parseError) {
       console.error('JSON 파싱 오류:', parseError);
       return null;

--- a/utils/emotionAnalyzer.js
+++ b/utils/emotionAnalyzer.js
@@ -32,13 +32,13 @@ export class EmotionAnalyzer {
 
   calculateEmotionScore(emotions) {
     const WEIGHTS = {
-      기쁨: +1,
-      슬픔: -1,
-      분노: -1,
-      두려움: -0.8,
-      혐오: -0.9,
-      놀람: 0,
-      중립: 0
+      joy: +1,
+      sadness: -1,
+      anger: -1,
+      fear: -0.8,
+      disgust: -0.9,
+      surprise: 0,
+      neutral: 0
     };
     return Object.entries(emotions).reduce((score, [emotion, value]) => {
       return score + value * (WEIGHTS[emotion] || 0);


### PR DESCRIPTION
## Summary
- normalize OpenAI emotion response to English keys and numeric values
- update emotion analyzer weight keys to English

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b5fc55c832fb5f155cc963f2e78