### PR TITLE
Fix useForm touched handler name

### DIFF
--- a/hooks/index.js
+++ b/hooks/index.js
@@ -338,7 +338,7 @@ export const useForm = (initialValues = {}, validationRules = {}) => {
     }
   }, [validationRules, touched, values]);
 
-  const setTouched = useCallback((name) => {
+  const markTouched = useCallback((name) => {
     setTouched(prev => ({ ...prev, [name]: true }));
   }, []);
 
@@ -369,7 +369,7 @@ export const useForm = (initialValues = {}, validationRules = {}) => {
     errors,
     touched,
     setValue,
-    setTouched,
+    markTouched,
     validate,
     reset,
     isValid: Object.keys(errors).length === 0


### PR DESCRIPTION
## Summary
- rename internal callback `setTouched` to `markTouched` to avoid collision with state setter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa881acbc832fbe70ddb03a25f5b7