### PR TITLE
Update signIn and signUp return shape

### DIFF
--- a/hooks/index.js
+++ b/hooks/index.js
@@ -37,7 +37,7 @@ export const useAuth = () => {
       if (error) throw error;
       
       setSession(data.session);
-      setUser(data.session.user);
+      setUser(data.user ?? data.session?.user ?? null);
       return { success: true, error: null };
     } catch (error) {
       devUtils.log('Sign in error:', error);

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -31,23 +31,27 @@ export const auth = {
 
   signUp: async (email, password, metadata = {}) => {
     try {
-      const { data, error } = await supabase.auth.signUp({
+      const { session, user, data, error } = await supabase.auth.signUp({
         email,
         password,
         options: { data: metadata },
       });
-      return { data, error };
+      const sessionData = session ?? data ?? null;
+      const userData = user ?? sessionData?.user ?? null;
+      return { data: { session: sessionData, user: userData }, error };
     } catch (error) {
-      return { data: null, error };
+      return { data: { session: null, user: null }, error };
     }
   },
 
   signIn: async (email, password) => {
     try {
-      const { data, error } = await supabase.auth.signIn({ email, password });
-      return { data, error };
+      const { session, user, data, error } = await supabase.auth.signIn({ email, password });
+      const sessionData = session ?? data ?? null;
+      const userData = user ?? sessionData?.user ?? null;
+      return { data: { session: sessionData, user: userData }, error };
     } catch (error) {
-      return { data: null, error };
+      return { data: { session: null, user: null }, error };
     }
   },
 


### PR DESCRIPTION
## Summary
- update supabase auth helpers to always return `{ data: { session, user }, error }`
- access returned user data safely in `useAuth`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc16e7c34832f94a59fab3d195383