### PR TITLE
Add saveInnerTalk database helper

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -134,6 +134,39 @@ export const database = {
     }
   },
 
+  saveInnerTalk: async (talkData) => {
+    try {
+      const { userId } = await auth.getCurrentUserId();
+      const talkRecord = {
+        user_id: userId,
+        emotion_id: talkData.emotion_id || null,
+        user_input: talkData.user_input,
+        ai_reply: talkData.ai_reply,
+        created_at: new Date().toISOString(),
+        ...talkData
+      };
+
+      try {
+        const { data, error } = await supabase
+          .from('inner_talks')
+          .insert(talkRecord)
+          .select()
+          .single();
+        if (error) throw error;
+        await database.saveToLocalStorage('inner_talks', data);
+        return { data, error: null };
+      } catch (dbError) {
+        console.error('Supabase saveInnerTalk error:', dbError);
+        const localData = { ...talkRecord, id: Date.now().toString() };
+        await database.saveToLocalStorage('inner_talks', localData);
+        return { data: localData, error: null };
+      }
+    } catch (error) {
+      console.error('saveInnerTalk error:', error);
+      return { data: null, error };
+    }
+  },
+
   getEmotions: async (limit = 10, offset = 0) => {
     try {
       const { userId } = await auth.getCurrentUserId();


### PR DESCRIPTION
## Summary
- add a `saveInnerTalk` helper in `supabase.js`
- log errors and fall back to local storage when Supabase insert fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc48b0754832fa0502558bd22b987