### PR TITLE
Add EmotionStats screen with charts

### DIFF
--- a/App.js
+++ b/App.js
@@ -18,6 +18,7 @@ import HomeScreen from './screens/HomeScreen';
 import InnerTalkScreen from './screens/InnerTalkScreen';
 import EmotionAnalysisScreen from './screens/EmotionAnalysisScreen';
 import EmotionResultScreen from './screens/EmotionResultScreen';
+import EmotionStatsScreen from './screens/EmotionStatsScreen';
 
 const Stack = createStackNavigator();
 const Tab = createBottomTabNavigator();
@@ -66,7 +67,7 @@ const InsightsScreen = ({ navigation }) => (
   </View>
 );
 
-const ProfileScreen = () => {
+const ProfileScreen = ({ navigation }) => {
   const { user, isAuthenticated, signIn, signUp, signOut, loading } = useAuth();
   const { control, handleSubmit, reset } = useForm();
   const [mode, setMode] = useState('signin');
@@ -118,6 +119,11 @@ const ProfileScreen = () => {
                 <Text style={styles.insightText}>주요 감정: {insights.mostCommonEmotion}</Text>
               </View>
             )}
+            <TouchableOpacity style={styles.modernButton} onPress={() => navigation.navigate('EmotionStats')}>
+              <LinearGradient colors={['#6366F1', '#8B5CF6']} style={styles.buttonGradient}>
+                <Text style={styles.buttonText}>통계 상세 보기</Text>
+              </LinearGradient>
+            </TouchableOpacity>
             <TouchableOpacity style={styles.modernButton} onPress={signOut} disabled={loading}>
               <LinearGradient colors={['#EF4444', '#F59E0B']} style={styles.buttonGradient}>
                 <Text style={styles.buttonText}>로그아웃</Text>
@@ -258,6 +264,7 @@ export default function App() {
           <Stack.Screen name="MainTabs" component={MainTabs} />
           <Stack.Screen name="EmotionAnalysis" component={EmotionAnalysisScreen} options={{ headerShown: true, title: '감정 분석', headerStyle: { backgroundColor: '#FEFCF0', shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.1, shadowRadius: 4, elevation: 4 }, headerTitleStyle: { color: '#1F2937', fontWeight: '600', fontSize: 18 }, headerTintColor: '#7C3AED' }} />
           <Stack.Screen name="EmotionResultScreen" component={EmotionResultScreen} options={{ headerShown: true, title: '감정 결과', headerStyle: { backgroundColor: '#FEFCF0' }, headerTintColor: '#7C3AED', headerTitleStyle: { fontWeight: '600', fontSize: 18 } }} />
+          <Stack.Screen name="EmotionStats" component={EmotionStatsScreen} options={{ headerShown: true, title: '감정 통계', headerStyle: { backgroundColor: '#FEFCF0' }, headerTintColor: '#7C3AED', headerTitleStyle: { fontWeight: '600', fontSize: 18 } }} />
         </Stack.Navigator>
       </NavigationContainer>
     </View>

--- a/screens/EmotionStatsScreen.js
+++ b/screens/EmotionStatsScreen.js
@@ -1,0 +1,137 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Dimensions, TouchableOpacity } from 'react-native';
+import { LineChart, PieChart } from 'react-native-chart-kit';
+import { analytics } from '../lib/supabase';
+import { emotionAnalyzer } from '../utils/emotionAnalyzer';
+
+const { width } = Dimensions.get('window');
+
+const chartConfig = {
+  backgroundGradientFrom: '#fff',
+  backgroundGradientTo: '#fff',
+  decimalPlaces: 2,
+  color: (opacity = 1) => `rgba(124, 58, 237, ${opacity})`,
+  labelColor: (opacity = 1) => `rgba(55, 65, 81, ${opacity})`,
+  style: { borderRadius: 16 },
+};
+
+const rangeOptions = [7, 30];
+
+const EmotionStatsScreen = () => {
+  const [range, setRange] = useState(7);
+  const [stats, setStats] = useState(null);
+  const [trendSlope, setTrendSlope] = useState(0);
+
+  const loadStats = async (days) => {
+    const { data } = await analytics.getEmotionPatterns(days);
+    if (data) {
+      setStats(data);
+      const moods = data.moodTrends.map(t => t.averageMood);
+      setTrendSlope(emotionAnalyzer.calculateTrend(moods));
+    }
+  };
+
+  useEffect(() => { loadStats(range); }, [range]);
+
+  if (!stats) {
+    return (
+      <View style={styles.center}>\n        <Text style={styles.loading}>Loading...</Text>\n      </View>
+    );
+  }
+
+  const pieData = Object.keys(stats.emotionDistribution).map((key, i) => ({
+    name: key,
+    population: stats.emotionDistribution[key],
+    color: chartColors[i % chartColors.length],
+    legendFontColor: '#333',
+    legendFontSize: 12,
+  }));
+
+  const lineData = {
+    labels: stats.moodTrends.map(t => t.date.slice(5)),
+    datasets: [{
+      data: stats.moodTrends.map(t => t.averageMood),
+      color: () => '#7C3AED',
+      strokeWidth: 2,
+    }],
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.rangeTabs}>
+        {rangeOptions.map(option => (
+          <TouchableOpacity key={option} onPress={() => setRange(option)} style={[styles.tab, range === option && styles.activeTab]}>\n            <Text style={range === option ? styles.activeTabText : styles.tabText}>{option}일</Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <Text style={styles.sectionTitle}>감정 분포</Text>
+      <PieChart
+        data={pieData}
+        width={width - 40}
+        height={220}
+        chartConfig={chartConfig}
+        accessor="population"
+        backgroundColor="transparent"
+        paddingLeft="20"
+      />
+
+      <Text style={styles.sectionTitle}>기분 추세</Text>
+      <LineChart
+        data={lineData}
+        width={width - 40}
+        height={220}
+        chartConfig={chartConfig}
+        bezier
+        style={{ marginVertical: 8 }}
+      />
+      <Text style={styles.trendText}>최근 추세 기울기: {trendSlope.toFixed(2)}</Text>
+    </View>
+  );
+};
+
+const chartColors = [
+  '#FF6384', '#36A2EB', '#FFCE56', '#4BC0C0', '#9966FF', '#FF9F40', '#FFCD56',
+];
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FEFCF0',
+    padding: 20,
+  },
+  center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  loading: { fontSize: 16, color: '#374151' },
+  rangeTabs: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginBottom: 12,
+  },
+  tab: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    marginHorizontal: 4,
+    borderRadius: 8,
+    backgroundColor: '#E5E7EB',
+  },
+  activeTab: {
+    backgroundColor: '#7C3AED',
+  },
+  tabText: { color: '#374151' },
+  activeTabText: { color: '#fff', fontWeight: '600' },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#1F2937',
+    marginTop: 16,
+    marginBottom: 8,
+  },
+  trendText: {
+    textAlign: 'center',
+    fontSize: 14,
+    marginTop: 8,
+    color: '#4B5563',
+  },
+});
+
+export default EmotionStatsScreen;

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -58,9 +58,9 @@ const HomeScreen = ({ navigation }) => {
               <Text style={styles.actionText}>대화하기</Text>
             </TouchableOpacity>
             
-            <TouchableOpacity 
+            <TouchableOpacity
               style={styles.actionCard}
-              onPress={() => navigation.navigate('Insights')}
+              onPress={() => navigation.navigate('EmotionStats')}
               activeOpacity={0.7}
             >
               <Text style={styles.actionEmoji}>📊</Text>


### PR DESCRIPTION
## Summary
- add `EmotionStatsScreen` for viewing emotion patterns
- link to EmotionStats from Home and Profile screens
- register screen in navigation stack
- compute trend slope using emotion analyzer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc49c35c8832fb8f9a6cfa175a2db