### PR TITLE
Handle missing user_emotions column

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -180,18 +180,22 @@ export const database = {
         user_input: talkData.user_input,
         ai_reply: talkData.ai_reply,
         created_at: new Date().toISOString(),
-        ...talkData
+        user_emotions: talkData.user_emotions || null
       };
+
+      const insertRecord = { ...talkRecord };
+      delete insertRecord.user_emotions;
 
       try {
         const { data, error } = await supabase
           .from('inner_talks')
-          .insert(talkRecord)
+          .insert(insertRecord)
           .select()
           .single();
         if (error) throw error;
-        await database.saveToLocalStorage('inner_talks', data);
-        return { data, error: null };
+        const recordWithEmotions = { ...data, user_emotions: talkRecord.user_emotions };
+        await database.saveToLocalStorage('inner_talks', recordWithEmotions);
+        return { data: recordWithEmotions, error: null };
       } catch (dbError) {
         console.error('Supabase saveInnerTalk error:', dbError);
         const localData = { ...talkRecord, id: Date.now().toString() };


### PR DESCRIPTION
## Summary
- avoid sending `user_emotions` to Supabase when saving inner talks
- keep the value in local storage for later use

## Testing
- `npx -y jest` *(fails: Preset react-native not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840fcacda1c832fb456b31f262f1634