### PR TITLE
Fix trend function edge cases and export GPT util

### DIFF
--- a/__tests__/utils/emotionAnalyzer.test.js
+++ b/__tests__/utils/emotionAnalyzer.test.js
@@ -27,4 +27,9 @@ describe('EmotionAnalyzer utility functions', () => {
     const trend = analyzer.calculateTrend([1, 2, 3, 4]);
     expect(trend).toBeCloseTo(1);
   });
+
+  test('calculateTrend returns 0 for insufficient data', () => {
+    expect(analyzer.calculateTrend([5])).toBe(0);
+    expect(analyzer.calculateTrend([])).toBe(0);
+  });
 });

--- a/utils/emotionAnalyzer.js
+++ b/utils/emotionAnalyzer.js
@@ -117,12 +117,18 @@ export class EmotionAnalyzer {
 
   calculateTrend(values) {
     const n = values.length;
+    if (n <= 1) return 0;
+
     const x = Array.from({ length: n }, (_, i) => i);
     const sumX = x.reduce((a, b) => a + b, 0);
     const sumY = values.reduce((a, b) => a + b, 0);
     const sumXY = x.reduce((sum, xi, i) => sum + xi * values[i], 0);
     const sumXX = x.reduce((sum, xi) => sum + xi * xi, 0);
-    return (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+
+    const denominator = n * sumXX - sumX * sumX;
+    if (denominator === 0) return 0;
+
+    return (n * sumXY - sumX * sumY) / denominator;
   }
 }
 

--- a/utils/gpt-integration.js
+++ b/utils/gpt-integration.js
@@ -1,5 +1,5 @@
   // 실제 GPT API 호출 함수
-  const analyzeEmotionWithGPT = async (emotionText) => {
+export const analyzeEmotionWithGPT = async (emotionText) => {
     try {
       const response = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
@@ -116,3 +116,5 @@
       };
     }
   };
+
+export default analyzeEmotionWithGPT;


### PR DESCRIPTION
## Summary
- handle small datasets in emotion trend calculation
- add test coverage for small trend inputs
- export analyzeEmotionWithGPT for reuse

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684107a7d8e8832fa7a369bd8db4a66f