### PR TITLE
Fix inner talk emotion save

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -184,24 +184,15 @@ export const database = {
         ai_emotions: talkData.ai_emotions || null
       };
 
-      const insertRecord = { ...talkRecord };
-      delete insertRecord.user_emotions;
-      delete insertRecord.ai_emotions;
-
       try {
         const { data, error } = await supabase
           .from('inner_talks')
-          .insert(insertRecord)
+          .insert(talkRecord)
           .select()
           .single();
         if (error) throw error;
-        const recordWithEmotions = {
-          ...data,
-          user_emotions: talkRecord.user_emotions,
-          ai_emotions: talkRecord.ai_emotions
-        };
-        await database.saveToLocalStorage('inner_talks', recordWithEmotions);
-        return { data: recordWithEmotions, error: null };
+        await database.saveToLocalStorage('inner_talks', data);
+        return { data, error: null };
       } catch (dbError) {
         console.error('Supabase saveInnerTalk error:', dbError?.message || dbError);
         const localData = { ...talkRecord, id: Date.now().toString() };


### PR DESCRIPTION
## Summary
- store `user_emotions` and `ai_emotions` directly in the `inner_talks` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841adc290d0832fae611ec9372fa466