### PR TITLE
Add coachingTalk mode

### DIFF
--- a/screens/InnerTalkScreen.js
+++ b/screens/InnerTalkScreen.js
@@ -24,6 +24,7 @@ const InnerTalkScreen = ({ route }) => {
   const [aiReply, setAiReply] = useState(null);
   const [loading, setLoading] = useState(false);
   const [history, setHistory] = useState([]);
+  const [mode, setMode] = useState('inner');
   const scrollViewRef = useRef(null);
 
   useEffect(() => {
@@ -50,8 +51,10 @@ const InnerTalkScreen = ({ route }) => {
 
     try {
       // Perform AI reply and emotion analysis concurrently
+      const talkFn =
+        mode === 'coaching' ? openAIService.coachingTalk : openAIService.innerTalk;
       const [response, userEmotions] = await Promise.all([
-        openAIService.innerTalk(newHistory),
+        talkFn(newHistory),
         openAIService.getEmotionSummary(userThought)
       ]);
 
@@ -102,6 +105,20 @@ const InnerTalkScreen = ({ route }) => {
     >
       <SafeAreaView style={styles.container}>
       <Text style={styles.title}>내면 대화</Text>
+      <View style={styles.modeToggle}>
+        <TouchableOpacity
+          style={[styles.modeButton, mode === 'inner' && styles.modeButtonActive]}
+          onPress={() => setMode('inner')}
+        >
+          <Text style={[styles.modeText, mode === 'inner' && styles.modeTextActive]}>상담</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.modeButton, mode === 'coaching' && styles.modeButtonActive]}
+          onPress={() => setMode('coaching')}
+        >
+          <Text style={[styles.modeText, mode === 'coaching' && styles.modeTextActive]}>코칭</Text>
+        </TouchableOpacity>
+      </View>
       <ScrollView
         ref={scrollViewRef}
         style={styles.scrollView}
@@ -150,6 +167,28 @@ const styles = StyleSheet.create({
     marginTop: 16,
     marginBottom: 8,
     color: '#2D3748',
+  },
+  modeToggle: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginBottom: 8,
+    gap: 12,
+  },
+  modeButton: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    backgroundColor: '#E2E8F0',
+  },
+  modeButtonActive: {
+    backgroundColor: '#4A5568',
+  },
+  modeText: {
+    fontSize: 14,
+    color: '#2D3748',
+  },
+  modeTextActive: {
+    color: '#FFFFFF',
   },
   scrollView: {
     flex: 1,

--- a/services/openai.js
+++ b/services/openai.js
@@ -111,6 +111,40 @@ export const innerTalk = async (messages = []) => {
 };
 
 /**
+ * 변화 코칭 대화 생성
+ * @param {Array<{role: string, content: string}>} messages 대화 기록
+ * @returns {Promise<{success: boolean, data?: string}>}
+ */
+export const coachingTalk = async (messages = []) => {
+  const systemPrompt = `당신은 사용자가 자신의 감정을 표현하고 원인을 탐색할 수 있도록 돕는 코칭 전문가입니다. 대화는 "감정 표현 → 원인 탐색 → 변화 제안" 순서로 진행합니다. "혹시 어떤 욕구가 충족되지 않아서일까요?"와 같이 욕구를 살피는 질문을 사용하고, 사용자의 말에 "항상 그래야 한다"와 같은 고정관념이 보이면 부드럽게 알려주세요. 마지막에는 작은 행동 변화를 제안하여 대화를 마무리합니다.`;
+
+  try {
+    const res = await global.fetch(OPENAI_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          ...messages,
+        ],
+        temperature: 0.7,
+      }),
+    });
+
+    const data = await res.json();
+    const reply = data?.choices?.[0]?.message?.content?.trim();
+    return reply ? { success: true, data: reply } : { success: false };
+  } catch (err) {
+    console.error('coachingTalk 오류:', err);
+    return { success: false };
+  }
+};
+
+/**
  * CBT 세션 인사이트 생성
  * @param {Object} sessionData - 세션 데이터
  * @returns {Promise<{success: boolean, insights?: string}>}
@@ -144,4 +178,9 @@ export const generateCBTInsights = async (sessionData) => {
   }
 };
 
-export default { getEmotionSummary, innerTalk, generateCBTInsights };
+export default {
+  getEmotionSummary,
+  innerTalk,
+  coachingTalk,
+  generateCBTInsights,
+};


### PR DESCRIPTION
## Summary
- add a new OpenAI helper `coachingTalk`
- allow InnerTalkScreen to switch between CBT and coaching prompts

## Testing
- `npx -y jest` *(fails: Preset react-native not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841cd051cbc832fb918b6294ee3680d