### PR TITLE
Add admin dashboard analytics

### DIFF
--- a/App.js
+++ b/App.js
@@ -19,6 +19,7 @@ import InnerTalkScreen from './screens/InnerTalkScreen';
 import EmotionAnalysisScreen from './screens/EmotionAnalysisScreen';
 import EmotionResultScreen from './screens/EmotionResultScreen';
 import EmotionStatsScreen from './screens/EmotionStatsScreen';
+import AdminDashboardScreen from './screens/AdminDashboardScreen';
 
 // Suppress known non-critical warnings/errors
 LogBox.ignoreLogs([
@@ -134,6 +135,11 @@ const ProfileScreen = ({ navigation }) => {
             <TouchableOpacity style={styles.modernButton} onPress={() => navigation.navigate('EmotionStats')}>
               <LinearGradient colors={['#6366F1', '#8B5CF6']} style={styles.buttonGradient}>
                 <Text style={styles.buttonText}>통계 상세 보기</Text>
+              </LinearGradient>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.modernButton} onPress={() => navigation.navigate('AdminDashboard')}>
+              <LinearGradient colors={['#10B981', '#6EE7B7']} style={styles.buttonGradient}>
+                <Text style={styles.buttonText}>Admin Dashboard</Text>
               </LinearGradient>
             </TouchableOpacity>
             <TouchableOpacity style={styles.modernButton} onPress={signOut} disabled={loading}>
@@ -306,6 +312,7 @@ export default function App() {
           <Stack.Screen name="EmotionAnalysis" component={EmotionAnalysisScreen} options={{ headerShown: true, title: '감정 분석', headerStyle: { backgroundColor: '#FEFCF0', shadowColor: '#000', shadowOffset: { width: 0, height: 1 }, shadowOpacity: 0.1, shadowRadius: 4, elevation: 4 }, headerTitleStyle: { color: '#1F2937', fontWeight: '600', fontSize: 18 }, headerTintColor: '#7C3AED' }} />
           <Stack.Screen name="EmotionResultScreen" component={EmotionResultScreen} options={{ headerShown: true, title: '감정 결과', headerStyle: { backgroundColor: '#FEFCF0' }, headerTintColor: '#7C3AED', headerTitleStyle: { fontWeight: '600', fontSize: 18 } }} />
           <Stack.Screen name="EmotionStats" component={EmotionStatsScreen} options={{ headerShown: true, title: '감정 통계', headerStyle: { backgroundColor: '#FEFCF0' }, headerTintColor: '#7C3AED', headerTitleStyle: { fontWeight: '600', fontSize: 18 } }} />
+          <Stack.Screen name="AdminDashboard" component={AdminDashboardScreen} options={{ headerShown: true, title: 'Admin Dashboard', headerStyle: { backgroundColor: '#FEFCF0' }, headerTintColor: '#7C3AED', headerTitleStyle: { fontWeight: '600', fontSize: 18 } }} />
         </Stack.Navigator>
       </NavigationContainer>
     </View>

--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { emotionAnalyzer } from '../utils/emotionAnalyzer';
 
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
@@ -231,6 +232,20 @@ export const database = {
     }
   },
 
+  getAllEmotions: async (limit = 10, offset = 0) => {
+    try {
+      const { data, error } = await supabase
+        .from('emotions')
+        .select('*')
+        .order('created_at', { ascending: false })
+        .range(offset, offset + limit - 1);
+      if (error) throw error;
+      return { data, error: null };
+    } catch (error) {
+      return { data: [], error };
+    }
+  },
+
   saveToLocalStorage: async (table, data) => {
     try {
       const existingData = await database.getFromLocalStorage(table);
@@ -333,6 +348,93 @@ export const analytics = {
       return { data: analysis, error: null };
     } catch (error) {
       return { data: null, error };
+    }
+  },
+
+  getGlobalEmotionPatterns: async (days = 30) => {
+    try {
+      const { data: emotions } = await database.getAllEmotions(1000);
+      if (!emotions || emotions.length === 0) {
+        return { data: null, error: 'No emotion data available' };
+      }
+
+      const cutoffDate = new Date();
+      cutoffDate.setDate(cutoffDate.getDate() - days);
+
+      const recent = emotions.filter(e => new Date(e.created_at) >= cutoffDate);
+
+      const counts = {};
+      recent.forEach(e => {
+        counts[e.primary_emotion] = (counts[e.primary_emotion] || 0) + 1;
+      });
+
+      const analysis = {
+        totalEntries: recent.length,
+        emotionDistribution: counts,
+        mostCommonEmotion: Object.entries(counts).sort(([,a],[,b]) => b-a)[0]?.[0] || null,
+        averageIntensity: recent.reduce((s,e)=> s + e.intensity,0) / recent.length,
+        period: `${days} days`
+      };
+
+      return { data: analysis, error: null };
+    } catch (error) {
+      return { data: null, error };
+    }
+  },
+
+  detectAbnormalUsers: async (days = 7) => {
+    try {
+      const { data: emotions } = await database.getAllEmotions(1000);
+      if (!emotions) return { data: [], error: null };
+
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - days);
+
+      const byUser = {};
+      emotions.forEach(e => {
+        if (new Date(e.created_at) >= cutoff) {
+          if (!byUser[e.user_id]) byUser[e.user_id] = [];
+          byUser[e.user_id].push(e);
+        }
+      });
+
+      const negatives = ['sadness','anger','fear','disgust'];
+      const result = [];
+
+      Object.entries(byUser).forEach(([uid,list]) => {
+        list.sort((a,b)=> new Date(a.created_at) - new Date(b.created_at));
+        let swings = 0;
+        let streak = 0;
+        let maxStreak = 0;
+        for(let i=1;i<list.length;i++) {
+          const prev=list[i-1];
+          const curr=list[i];
+          if(Math.abs((curr.intensity||0)-(prev.intensity||0))>=3) swings++;
+          if(negatives.includes(curr.primary_emotion)) {
+            streak++;
+            maxStreak = Math.max(maxStreak, streak);
+          } else {
+            streak = 0;
+          }
+        }
+        if (swings >= 3 || maxStreak >= 3) {
+          const counts = {};
+          list.forEach(e => {
+            counts[e.primary_emotion] = (counts[e.primary_emotion] || 0) + 1;
+          });
+          const rec = emotionAnalyzer.generateRecommendations(counts);
+          result.push({
+            user_id: uid,
+            moodSwings: swings,
+            negativeStreak: maxStreak,
+            recommended: Array.isArray(rec) ? rec[0] : rec,
+          });
+        }
+      });
+
+      return { data: result, error: null };
+    } catch (error) {
+      return { data: [], error };
     }
   }
 };

--- a/screens/AdminDashboardScreen.js
+++ b/screens/AdminDashboardScreen.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { analytics } from '../lib/supabase';
+
+const AdminDashboardScreen = () => {
+  const [stats, setStats] = useState(null);
+  const [abnormalUsers, setAbnormalUsers] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: global } = await analytics.getGlobalEmotionPatterns(30);
+      if (global) setStats(global);
+      const { data: abnormal } = await analytics.detectAbnormalUsers(7);
+      if (abnormal) setAbnormalUsers(abnormal);
+    };
+    load();
+  }, []);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      {stats && (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Summary</Text>
+          <Text style={styles.text}>Total entries: {stats.totalEntries}</Text>
+          <Text style={styles.text}>Most common emotion: {stats.mostCommonEmotion}</Text>
+          <Text style={styles.text}>Average intensity: {stats.averageIntensity.toFixed(2)}</Text>
+        </View>
+      )}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Users with Abnormal Trends</Text>
+        {abnormalUsers.length === 0 ? (
+          <Text style={styles.text}>No abnormal patterns detected.</Text>
+        ) : (
+          abnormalUsers.map((u) => (
+            <View key={u.user_id} style={styles.userBox}>
+              <Text style={styles.userId}>User: {u.user_id}</Text>
+              <Text style={styles.text}>Mood swings: {u.moodSwings}</Text>
+              <Text style={styles.text}>Negative streak: {u.negativeStreak}</Text>
+              <Text style={styles.text}>Follow-up: {u.recommended}</Text>
+            </View>
+          ))
+        )}
+      </View>
+    </ScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#FEFCF0' },
+  content: { padding: 20 },
+  section: { marginBottom: 24 },
+  sectionTitle: { fontSize: 18, fontWeight: '600', marginBottom: 8, color: '#1F2937' },
+  userBox: { padding: 12, borderRadius: 12, borderWidth: 1, borderColor: '#E5E7EB', backgroundColor: '#FFFFFF', marginBottom: 12 },
+  userId: { fontWeight: '600', marginBottom: 4, color: '#1F2937' },
+  text: { color: '#374151' },
+});
+
+export default AdminDashboardScreen;


### PR DESCRIPTION
## Summary
- implement `database.getAllEmotions`
- expand analytics module with global stats and abnormal trend detection
- add `AdminDashboardScreen` showing overall stats and flagged users
- include new navigation route and profile entry

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841cd28734c832fae6505fb5a74cf98