### PR TITLE
Add admin role support

### DIFF
--- a/App.js
+++ b/App.js
@@ -20,6 +20,8 @@ import InnerTalkScreen from './screens/InnerTalkScreen';
 import EmotionAnalysisScreen from './screens/EmotionAnalysisScreen';
 import EmotionResultScreen from './screens/EmotionResultScreen';
 import EmotionStatsScreen from './screens/EmotionStatsScreen';
+import AdminScreen from './screens/AdminScreen';
+import { ADMIN_EMAIL } from './config/admin';
 
 // Suppress known non-critical warnings/errors
 LogBox.ignoreLogs([
@@ -103,7 +105,11 @@ const ProfileScreen = ({ navigation }) => {
 
     let result;
     if (mode === 'signup') {
-      result = await signUp(email, password, { gender, birth_year: birthYear });
+      const metadata = { gender, birth_year: birthYear };
+      if (email === ADMIN_EMAIL) {
+        metadata.role = 'admin';
+      }
+      result = await signUp(email, password, metadata);
     } else {
       result = await signIn(email, password);
     }
@@ -251,6 +257,7 @@ const ProfileScreen = ({ navigation }) => {
 };
 
 function MainTabs() {
+  const { isAdmin } = useAuth();
   return (
     <Tab.Navigator screenOptions={{
       tabBarStyle: {
@@ -274,6 +281,9 @@ function MainTabs() {
       <Tab.Screen name="Home" component={HomeScreen} options={{ title: '홈', tabBarIcon: ({ focused }) => (<TabIcon focused={focused} emoji="🏡" activeEmoji="🏠" />) }} />
       <Tab.Screen name="InnerTalk" component={InnerTalkScreen} options={{ title: '대화', tabBarIcon: ({ focused }) => (<TabIcon focused={focused} emoji="💬" activeEmoji="💭" />) }} />
       <Tab.Screen name="Insights" component={InsightsScreen} options={{ title: '분석', tabBarIcon: ({ focused }) => (<TabIcon focused={focused} emoji="📈" activeEmoji="📊" />) }} />
+      {isAdmin && (
+        <Tab.Screen name="Admin" component={AdminScreen} options={{ title: '관리', tabBarIcon: ({ focused }) => (<TabIcon focused={focused} emoji="🛠" activeEmoji="⚙️" />) }} />
+      )}
       <Tab.Screen name="Profile" component={ProfileScreen} options={{ title: '프로필', tabBarIcon: ({ focused }) => (<TabIcon focused={focused} emoji="👥" activeEmoji="👤" />) }} />
     </Tab.Navigator>
   );

--- a/config/admin.js
+++ b/config/admin.js
@@ -1,0 +1,1 @@
+export const ADMIN_EMAIL = 'wsryang@gmail.com';

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -100,7 +100,8 @@ export const useAuth = () => {
     signIn,
     signUp,
     signOut,
-    isAuthenticated: !!session
+    isAuthenticated: !!session,
+    isAdmin: user?.user_metadata?.role === 'admin'
   };
 };
 

--- a/screens/AdminScreen.js
+++ b/screens/AdminScreen.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+const AdminScreen = () => (
+  <View style={styles.container}>
+    <Text style={styles.title}>Admin Panel</Text>
+    <Text style={styles.text}>관리자 전용 기능입니다.</Text>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FEFCF0',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 12,
+    color: '#1F2937',
+  },
+  text: {
+    fontSize: 16,
+    color: '#374151',
+  },
+});
+
+export default AdminScreen;


### PR DESCRIPTION
## Summary
- add ADMIN_EMAIL constant
- expose `isAdmin` from `useAuth`
- store admin role metadata on signup
- add Admin screen and tab visible only for admin users

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68421df4e350832f9b9ad65f08ecbdf2