### PR TITLE
Check env before creating Supabase client

### DIFF
--- a/lib/supabase.js
+++ b/lib/supabase.js
@@ -4,20 +4,53 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    storage: AsyncStorage,
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: false,
-  },
-  realtime: {
-    disabled: true,
-  },
-  global: {
-    fetch: fetch,
-  },
-});
+let supabase;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error(
+    'Missing Supabase environment variables: EXPO_PUBLIC_SUPABASE_URL or EXPO_PUBLIC_SUPABASE_ANON_KEY'
+  );
+  const error = new Error('Supabase not initialized');
+  const stubResult = Promise.resolve({ data: null, error });
+  const stubQuery = {
+    select: () => stubQuery,
+    insert: () => stubQuery,
+    upsert: () => stubQuery,
+    eq: () => stubQuery,
+    order: () => stubQuery,
+    single: () => stubResult,
+    range: () => stubResult,
+    then: (res, rej) => stubResult.then(res, rej),
+  };
+
+  supabase = {
+    auth: {
+      getSession: async () => ({ session: null, error }),
+      signUp: async () => ({ data: { session: null, user: null }, error }),
+      signIn: async () => ({ data: { session: null, user: null }, error }),
+      signOut: async () => ({ error }),
+      getUser: async () => ({ user: null, error }),
+    },
+    from: () => stubQuery,
+  };
+} else {
+  supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      storage: AsyncStorage,
+      autoRefreshToken: true,
+      persistSession: true,
+      detectSessionInUrl: false,
+    },
+    realtime: {
+      disabled: true,
+    },
+    global: {
+      fetch: fetch,
+    },
+  });
+}
+
+export { supabase };
 
 export const auth = {
   getSession: async () => {


### PR DESCRIPTION
## Summary
- prevent Supabase client initialization if env vars are absent
- provide stub client so calls won't crash

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b67abd04832fa7a0f35a7eee0264