### PR TITLE
Fix Android Gradle configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'com.android.application' version '8.1.2'
 }
 
+repositories {
+    google()
+    mavenCentral()
+    maven { url 'https://www.jitpack.io' }
+}
+
 ext {
     compileSdkVersion = 35
     minSdkVersion = 24
@@ -46,5 +52,5 @@ android {
 dependencies {
     implementation project(":expo")
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.facebook.react:react-native:0.79.3'
+    implementation 'com.facebook.react:react-native:0.73.6'
 }


### PR DESCRIPTION
## Summary
- ensure Gradle can resolve dependencies by defining repositories
- use the correct React Native version for Maven dependencies

## Testing
- `npm test` *(fails: jest not found)*
- `./gradlew assembleRelease` *(fails: Process 'command 'node'' finished with non-zero exit value 1)*

------
https://chatgpt.com/codex/tasks/task_e_6844c6507c58832fb315a6ab43e38bf1