### PR TITLE
Fix Android build dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,5 +52,5 @@ android {
 dependencies {
     implementation project(":expo")
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'com.facebook.react:react-native:0.73.6'
+    implementation 'com.facebook.react:react-android:0.73.6'
 }


### PR DESCRIPTION
## Summary
- correct the react native artifact name for Android build

## Testing
- `npx jest --maxWorkers=2` *(fails: Preset react-native not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c78f88f8832faad7f8d687b3b3ed